### PR TITLE
Feature: Multiple keys and custom templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Make sure you include the `<script>` in your project (choose one of these):
 <!-- 3rd party CDN, not recommended for production use -->
 <script
   type="module"
-  src="https://www.unpkg.com/@daviddarnes/mastodon-post@1.0.0/mastodon-post.js"
+  src="https://www.unpkg.com/@daviddarnes/mastodon-post@1.3.0/mastodon-post.js"
 ></script>
 ```
 
@@ -101,7 +101,7 @@ Make sure you include the `<script>` in your project (choose one of these):
 <!-- 3rd party CDN, not recommended for production use -->
 <script
   type="module"
-  src="https://esm.sh/@daviddarnes/mastodon-post@1.0.0"
+  src="https://esm.sh/@daviddarnes/mastodon-post@1.3.0"
 ></script>
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This Web Component allows you to:
 - Turn a regular Mastodon post link into a quoted Mastodon post
 - Surface the post metadata alongside the post, e.g. reply count, reblog count, favourite count
 - Use a custom template for all instances of the component on the page using a `data-key="name"` data attributes
+- Use a custom template for specific instances using the `template` attribute
 - Retrieve nested data using the `data-key` attribute and typical JavaScript key referencing, e.g. `data-key="account.display_name"` or `data-key="media_attachments[0]preview_url"`
 
 ## Installation
@@ -144,6 +145,20 @@ However you can customise the template by using a `<template>` element with an `
     <dd data-key="favourites_count"></dd>
   </dl>
 </template>
+```
+
+You can also use different templates on the same page by using the `template` attribute to target `<template>` elements with a specific `id`:
+
+```html
+<template id="custom-template">
+  <a data-key="content, url"></a>
+</template>
+
+<mastodon-post template="custom-template">
+  <a href="https://mastodon.design/@DavidDarnes/109824258017750161">
+    Discuss on Mastodon
+  </a>
+</mastodon-post>
 ```
 
 Data is applied using a `data-key` data attribute. The value of this attribute should correspond to a data point within a [Mastodon public status API response](https://docs.joinmastodon.org/methods/statuses/). The official Mastodon documentation has [an example of a status response here](https://docs.joinmastodon.org/methods/statuses/#200-ok-1). The `data-key` attribute also allows you to target nested data using typical JavaScript dot notation:

--- a/demo-custom-template.html
+++ b/demo-custom-template.html
@@ -51,11 +51,8 @@
         <dt>Favourites</dt>
         <dd data-key="favourites_count"></dd>
       </dl>
-      <a data-key="url">
-        View original post from <img alt="avatar" data-key="account.avatar" />
-        <strong data-key="account.display_name"></strong> on
-        <strong data-key="hostname"></strong>
-      </a>
+      <a data-key="url">View original post</a> from
+      <a data-key="account.display_name, account.url"></a>
     </template>
 
     <h2>Custom template example</h2>

--- a/demo-custom-template.html
+++ b/demo-custom-template.html
@@ -11,7 +11,7 @@
         font-family: system-ui;
       }
 
-      mastodon-post:defined a:not([data-key]) {
+      mastodon-post[template="custom-template"]:defined a:not([data-key]) {
         display: none;
       }
 
@@ -42,6 +42,8 @@
     <script type="module" src="mastodon-post.js"></script>
   </head>
   <body>
+    <h2>Custom template example</h2>
+
     <template id="mastodon-post-template">
       <dl>
         <dt>Reposts</dt>
@@ -51,12 +53,21 @@
         <dt>Favourites</dt>
         <dd data-key="favourites_count"></dd>
       </dl>
-      <a data-key="url">View original post</a> from
-      <a data-key="account.display_name, account.url"></a>
     </template>
 
-    <h2>Custom template example</h2>
     <mastodon-post>
+      <a href="https://mastodon.design/@DavidDarnes/109824258017750161">
+        Discuss on Mastodon
+      </a>
+    </mastodon-post>
+
+    <h2>Custom template example using <code>template</code> attribute</h2>
+
+    <template id="custom-template">
+      <a data-key="content, url"></a>
+    </template>
+
+    <mastodon-post template="custom-template">
       <a href="https://mastodon.design/@DavidDarnes/109824258017750161">
         Discuss on Mastodon
       </a>

--- a/mastodon-post.js
+++ b/mastodon-post.js
@@ -78,7 +78,9 @@ class MastodonPost extends HTMLElement {
 
   get template() {
     return document
-      .getElementById(`${this.localName}-template`)
+      .getElementById(
+        this.getAttribute("template") || `${this.localName}-template`
+      )
       .content.cloneNode(true);
   }
 

--- a/mastodon-post.js
+++ b/mastodon-post.js
@@ -37,15 +37,17 @@ class MastodonPost extends HTMLElement {
     this.slots.forEach((slot) => {
       slot.dataset.key.split(",").forEach((keyItem) => {
         const value = this.getValue(keyItem, data);
-        this.populateSlot(slot, keyItem, value);
+        if (keyItem === "content") {
+          slot.innerHTML = value;
+        } else {
+          this.populateSlot(slot, value);
+        }
       });
     });
   }
 
-  populateSlot(slot, keyItem, value) {
-    if (keyItem === "content") {
-      slot.innerHTML = value;
-    } else if (typeof value == "string" && value.startsWith("http")) {
+  populateSlot(slot, value) {
+    if (typeof value == "string" && value.startsWith("http")) {
       if (slot.localName === "img") slot.src = value;
       if (slot.localName === "a") slot.href = value;
     } else {
@@ -76,7 +78,7 @@ class MastodonPost extends HTMLElement {
 
   get template() {
     return document
-      .getElementById(mastodonPostTemplate.id)
+      .getElementById(`${this.localName}-template`)
       .content.cloneNode(true);
   }
 

--- a/mastodon-post.js
+++ b/mastodon-post.js
@@ -34,19 +34,23 @@ class MastodonPost extends HTMLElement {
 
     const data = { ...(await this.data), ...this.linkData };
 
-    this.querySelectorAll("[data-key]").forEach(async (slot) => {
-      const { key } = slot.dataset;
-      const value = this.getValue(key, data);
-
-      if (key === "content") {
-        slot.innerHTML = value;
-      } else if (typeof value === "string" && value.startsWith("http")) {
-        if (slot.localName === "a") slot.href = value;
-        if (slot.localName === "img") slot.src = value;
-      } else {
-        slot.textContent = value;
-      }
+    this.slots.forEach((slot) => {
+      slot.dataset.key.split(",").forEach((keyItem) => {
+        const value = this.getValue(keyItem, data);
+        this.populateSlot(slot, keyItem, value);
+      });
     });
+  }
+
+  populateSlot(slot, keyItem, value) {
+    if (keyItem === "content") {
+      slot.innerHTML = value;
+    } else if (typeof value == "string" && value.startsWith("http")) {
+      if (slot.localName === "img") slot.src = value;
+      if (slot.localName === "a") slot.href = value;
+    } else {
+      slot.textContent = value;
+    }
   }
 
   handleKey(object, key) {
@@ -60,7 +64,7 @@ class MastodonPost extends HTMLElement {
   }
 
   getValue(string, data) {
-    let keys = string.split(/\.|\[|\]/g);
+    let keys = string.trim().split(/\.|\[|\]/g);
     keys = keys.filter((string) => string.length);
 
     const value = keys.reduce(
@@ -76,6 +80,10 @@ class MastodonPost extends HTMLElement {
       .content.cloneNode(true);
   }
 
+  get slots() {
+    return this.querySelectorAll("[data-key]");
+  }
+
   get link() {
     return this.querySelector("a").href;
   }
@@ -87,7 +95,7 @@ class MastodonPost extends HTMLElement {
       url: this.link,
       hostname: url.hostname,
       username: paths.find((path) => path.startsWith("@")),
-      postId: paths.find((path) => !path.startsWith("@")),
+      postId: paths.find((path) => !path.startsWith("@"))
     };
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daviddarnes/mastodon-post",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A Web Component to display Mastodon posts and their metadata",
   "main": "mastodon-post.js",
   "scripts": {


### PR DESCRIPTION
- [x] Allow the use of multiple data keys on a single element, for example `<a data-key="content, url"></a>`
- [x] Allow the use of multiple templates on a single page, using a `template` attribute to target different `<template>`s with a matching ID #5 
- [x] Refactor methods for better open source development #4 